### PR TITLE
Fixed missing }

### DIFF
--- a/Praat Met De Ai/Program.cs
+++ b/Praat Met De Ai/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 
 namespace Praat_Met_De_Ai
 {
@@ -51,5 +50,6 @@ namespace Praat_Met_De_Ai
 
             Console.WriteLine($"Dankje, dankje. Nou ik moet maar eens gaan {name}. Doei doei!!!");
 
+        }
     }
 }


### PR DESCRIPTION
Er ontbrak een `}`. Ik heb ook een ongebruikte `using` verwijderd. Dat komt nog wel een keer 😉 